### PR TITLE
- Added new config feature "formats" - Supported HEAD tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,8 @@ Router.prototype.dispatch = function(request, response) {
   var that = this;
   var httpContext = this.httpContext = new HttpContext(request, response);
 
+  httpContext.format = {}; // initialize format object
+
   // parse body on post
   if (/(POST|PUT)/i.test(httpContext.request.method) && /(urlencoded|json|multipart\/form-data)/i.test(httpContext.request.headers['content-type'])) {
     var form = new formidable.IncomingForm();
@@ -113,13 +115,14 @@ Router.prototype.dispatch = function(request, response) {
 
 
 
-Router.prototype.use = function(method, urlformat, options, handle) {
+Router.prototype.use = function(method, urlformat, options, formats, handle) {
   var options = options || {},
     that = this;
-
+  
   options.handle = _.last(arguments);
   options.method = method.toUpperCase();
   options.query = _.pick(this.query, options.query);
+  options.formats = formats;
 
   if (options.timeout == null) {
     options.timeout = this.timeout; // default 30s timeout
@@ -156,7 +159,7 @@ Router.prototype.use = function(method, urlformat, options, handle) {
 
     // quick fail check
     if (matched || httpContext.request.method !== options.method) {
-        
+
       // check if httpContext.request.method isn't HEAD and router method isn't GET
         if (httpContext.request.method != 'HEAD' || options.method != 'GET') {
             next();
@@ -166,6 +169,27 @@ Router.prototype.use = function(method, urlformat, options, handle) {
             // HEAD method is identical to GET but MUST NOT return a message-body in the response
             httpContext.response._hasBody = false;
         }
+    }
+
+    // check if we have formats field in router config - example "formats": ["json, html, txt, xml"],
+    if (!_.isUndefined(options.formats) && _.isArray(options.formats) && !_.isEmpty(options.formats)) {
+
+      _.forEach(options.formats, function(format) {
+
+        var dotFormat = "." + format; // .json OR .html (/car-dealer/CA/Acura.html OR /car-dealer/CA/Acura.js)
+        var dotFormatIndex = httpContext.url.pathname.indexOf(dotFormat); // index of current format
+
+        // if current format is part of httpContext.url.pathname (/car-dealer/CA/Acura.json)
+        if (dotFormatIndex !== -1) {
+
+          // set format type to httpContext
+          httpContext.format[format] = true;
+
+          // remove dotFormat from path and pathname (/car-dealer/CA/Acura)
+          httpContext.url.pathname = httpContext.url.pathname.substr(0, dotFormatIndex);
+          httpContext.url.path = httpContext.url.path.substr(0, dotFormatIndex);
+        }
+      });
     }
 
     // evaluate hash for rest match

--- a/index.js
+++ b/index.js
@@ -156,8 +156,16 @@ Router.prototype.use = function(method, urlformat, options, handle) {
 
     // quick fail check
     if (matched || httpContext.request.method !== options.method) {
-      next();
-      return;
+        
+      // check if httpContext.request.method isn't HEAD and router method isn't GET
+        if (httpContext.request.method != 'HEAD' || options.method != 'GET') {
+            next();
+            return;
+        }
+        else {
+            // HEAD method is identical to GET but MUST NOT return a message-body in the response
+            httpContext.response._hasBody = false;
+        }
     }
 
     // evaluate hash for rest match


### PR DESCRIPTION
"formats" feature allows using the same route with different types (json, html, xml)

"detail": {
    "method": "GET",
    "path": "/vehicles/:vin",
    "handler": "detail",
    "browser": "true",
    "formats": ["json", "xml"],
    "params": {
        "vin": {
            "regex": "([A-Z\d]{17})-?.*",
            "kind": "rest",
            "enabled": true
        }
    },
    "enabled": true
}

Examples:

```
http://test.com/vehicles/19UUA9F25EA001983-used-2014-acura-tl--woodside

http://test.com/vehicles/19UUA9F25EA001983-used-2014-acura-tl--woodside.json

http://test.com/vehicles/19UUA9F25EA001983-used-2014-acura-tl--woodside.xml
```

And in controller we have reachable current type httpContext.format.json or httpContext.format.xml
